### PR TITLE
Fix merge Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "author": "anyul Rivas",
   "license": "ISC",
   "devDependencies": {
-    "sinon": "^9.0.1"
+    "sinon": "^9.0.1",
     "chai": "^4.2.0",
-    "enzyme": "^3.11.0",
+    "enzyme": "^3.11.0"
   },
   "dependencies": {
     "react": "^16.13.1",


### PR DESCRIPTION
Probably due to a manual merge, package.json became invalid JSON.

Please let us know if you think that Depfu caused this problem - I didn't take a too deep look at the commit history.

Cheers,

Jan (Cofounder Depfu)